### PR TITLE
Add specific NMEA messages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,11 @@ find_package(catkin REQUIRED COMPONENTS std_msgs message_generation)
 
 add_message_files(
   FILES
+  Gpgga.msg
+  Gpgsa.msg
+  Gpgsv.msg
+  GpgsvSatellite.msg
+  Gprmc.msg
   Sentence.msg
 )
 

--- a/msg/Gpgga.msg
+++ b/msg/Gpgga.msg
@@ -1,0 +1,25 @@
+# Message from GPGGA NMEA String
+Header header
+
+string message_id
+
+# UTC seconds from midnight
+float64 utc_seconds
+
+float64 lat
+float64 lon
+
+string lat_dir
+string lon_dir
+
+uint32 gps_qual
+
+uint32 num_sats
+float32 hdop 
+float32 alt
+string altitude_units
+
+float32 undulation
+string undulation_units
+uint32 diff_age
+string station_id

--- a/msg/Gpgga.msg
+++ b/msg/Gpgga.msg
@@ -23,3 +23,4 @@ float32 undulation
 string undulation_units
 uint32 diff_age
 string station_id
+

--- a/msg/Gpgga.msg
+++ b/msg/Gpgga.msg
@@ -23,4 +23,3 @@ float32 undulation
 string undulation_units
 uint32 diff_age
 string station_id
-

--- a/msg/Gpgsa.msg
+++ b/msg/Gpgsa.msg
@@ -1,0 +1,13 @@
+# Message from GPGSA NMEA String
+Header header
+
+string message_id
+
+string auto_manual_mode
+uint8 fix_mode
+
+uint8[] sv_ids
+
+float32 pdop
+float32 hdop
+float32 vdop

--- a/msg/Gpgsa.msg
+++ b/msg/Gpgsa.msg
@@ -11,3 +11,4 @@ uint8[] sv_ids
 float32 pdop
 float32 hdop
 float32 vdop
+

--- a/msg/Gpgsa.msg
+++ b/msg/Gpgsa.msg
@@ -11,4 +11,3 @@ uint8[] sv_ids
 float32 pdop
 float32 hdop
 float32 vdop
-

--- a/msg/Gpgsv.msg
+++ b/msg/Gpgsv.msg
@@ -1,0 +1,19 @@
+# Total number of satellites in view and data about satellites
+# Because the NMEA sentence is limited to 4 satellites per message, several
+# of these messages may need to be synthesized to get data about all visible
+# satellites.
+
+Header header
+
+string message_id
+
+# Number of messages in this sequence
+uint8 n_msgs
+# This messages number in its sequence. The first message is number 1.
+uint8 msg_number
+
+# Number of satellites currently visible
+uint8 n_satellites
+
+# Up to 4 satellites are described in each message
+GpgsvSatellite[] satellites

--- a/msg/Gpgsv.msg
+++ b/msg/Gpgsv.msg
@@ -17,3 +17,4 @@ uint8 n_satellites
 
 # Up to 4 satellites are described in each message
 GpgsvSatellite[] satellites
+

--- a/msg/Gpgsv.msg
+++ b/msg/Gpgsv.msg
@@ -17,4 +17,3 @@ uint8 n_satellites
 
 # Up to 4 satellites are described in each message
 GpgsvSatellite[] satellites
-

--- a/msg/GpgsvSatellite.msg
+++ b/msg/GpgsvSatellite.msg
@@ -1,0 +1,16 @@
+# Satellite data structure used in GPGSV messages
+
+# PRN number of the satellite
+# GPS = 1..32
+# SBAS = 33..64
+# GLO = 65..96
+uint8 prn
+
+# Elevation, degrees. Maximum 90
+uint8 elevation
+
+# Azimuth, True North degrees. [0, 359]
+uint16 azimuth
+
+# Signal to noise ratio, 0-99 dB. -1 when null in NMEA sentence (not tracking)
+int8 snr

--- a/msg/GpgsvSatellite.msg
+++ b/msg/GpgsvSatellite.msg
@@ -14,3 +14,4 @@ uint16 azimuth
 
 # Signal to noise ratio, 0-99 dB. -1 when null in NMEA sentence (not tracking)
 int8 snr
+

--- a/msg/GpgsvSatellite.msg
+++ b/msg/GpgsvSatellite.msg
@@ -14,4 +14,3 @@ uint16 azimuth
 
 # Signal to noise ratio, 0-99 dB. -1 when null in NMEA sentence (not tracking)
 int8 snr
-

--- a/msg/Gprmc.msg
+++ b/msg/Gprmc.msg
@@ -1,0 +1,20 @@
+# Message from GPRMC NMEA String
+Header header
+
+string message_id
+
+float64 utc_seconds
+string position_status
+
+float64 lat
+float64 lon
+
+string lat_dir
+string lon_dir
+
+float32 speed
+float32 track
+string date
+float32 mag_var
+string mag_var_direction
+string mode_indicator

--- a/msg/Gprmc.msg
+++ b/msg/Gprmc.msg
@@ -18,3 +18,4 @@ string date
 float32 mag_var
 string mag_var_direction
 string mode_indicator
+

--- a/msg/Gprmc.msg
+++ b/msg/Gprmc.msg
@@ -18,4 +18,3 @@ string date
 float32 mag_var
 string mag_var_direction
 string mode_indicator
-


### PR DESCRIPTION
Add messages for the following NMEA sentences:

- GPGGA
- GPGSA
- GPGSV (and a submessage GpgsvSatellite)
- GPRMC

These messages are useful to GPS drivers that parse NMEA sentences into specific ROS messages. See #4.