### PR TITLE
Add GPGST NMEA message

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ add_message_files(
   Gpgsv.msg
   GpgsvSatellite.msg
   Gprmc.msg
+  Gpgst.msg
   Sentence.msg
 )
 

--- a/msg/Gpgst.msg
+++ b/msg/Gpgst.msg
@@ -7,16 +7,16 @@ string message_id
 float64 utc_seconds
 
 # Root-Mean-Squared value of standard deviation of range inputs
-float64 rms
+float32 rms
 
 # Standard Deviations of semi-major and minor axes of error ellipse
-float64 semi_major_dev
-float64 semi_minor_dev
+float32 semi_major_dev
+float32 semi_minor_dev
 
 # Orientation of the semi-major axis of error ellipse with respect to true north
-float64 orientation
+float32 orientation
 
 # Standard Deviations of latitude, longitude, and altitude measurements
-float64 lat_dev
-float64 lon_dev
-float64 alt_dev
+float32 lat_dev
+float32 lon_dev
+float32 alt_dev

--- a/msg/Gpgst.msg
+++ b/msg/Gpgst.msg
@@ -1,0 +1,22 @@
+# Message from GPGST NMEA String
+Header header
+
+string message_id
+
+# UTC seconds from midnight
+float64 utc_seconds
+
+# Root-Mean-Squared value of standard deviation of range inputs
+float64 rms
+
+# Standard Deviations of semi-major and minor axes of error ellipse
+float64 semi_major_dev
+float64 semi_minor_dev
+
+# Orientation of the semi-major axis of error ellipse with respect to true north
+float64 orientation
+
+# Standard Deviations of latitude, longitude, and altitude measurements
+float64 lat_dev
+float64 lon_dev
+float64 alt_dev


### PR DESCRIPTION
Add a ROS message corresponding to the NMEA GPGST message. This message
contains statistical error information in the position estimate. This
is useful for consumers who use statistical filters to process GPS
messages.

See: #15 