### PR TITLE
bug fix and added two new sentences

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,8 @@ add_message_files(
   Gprmc.msg
   Gpgst.msg
   Sentence.msg
+  Gpvtg.msg
+  Gpzda.msg
 )
 
 generate_messages(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,9 +11,9 @@ add_message_files(
   GpgsvSatellite.msg
   Gprmc.msg
   Gpgst.msg
-  Sentence.msg
   Gpvtg.msg
   Gpzda.msg
+  Sentence.msg
 )
 
 generate_messages(

--- a/msg/Gpgga.msg
+++ b/msg/Gpgga.msg
@@ -21,5 +21,5 @@ string altitude_units
 
 float32 undulation
 string undulation_units
-uint32 diff_age
+float64 diff_age
 string station_id

--- a/msg/Gpgga.msg
+++ b/msg/Gpgga.msg
@@ -21,5 +21,5 @@ string altitude_units
 
 float32 undulation
 string undulation_units
-float64 diff_age
+uint32 diff_age
 string station_id

--- a/msg/Gpvtg.msg
+++ b/msg/Gpvtg.msg
@@ -4,20 +4,20 @@ Header header
 string message_id
 
 #track made good relative to true north
-float64 tmg_a
-string tmg_a_ref
+float64 track_t
+string track_t_ref
 
 # track made good relative to magnatic north
-float64 tmg_b
-string tmg_b_ref
+float64 track_m
+string track_m_ref
 
 # measured horizontal speed in knots
-float32 speed_a
-string speed_a_unit
+float32 speed_n
+string speed_n_unit
 
 # measured horizontal speed in km/hr
-float32 speed_b
-string speed_b_unit
+float32 speed_k
+string speed_k_unit
 
 # mode indicator
-string mode
+string mode_indicator

--- a/msg/Gpvtg.msg
+++ b/msg/Gpvtg.msg
@@ -8,7 +8,7 @@ float32 track_t
 string track_t_ref
 
 # track made good relative to magnatic north
-float64 track_m
+float32 track_m
 string track_m_ref
 
 # measured horizontal speed in knots

--- a/msg/Gpvtg.msg
+++ b/msg/Gpvtg.msg
@@ -3,21 +3,21 @@ Header header
 
 string message_id
 
-# track made good relative to true north
+# Track made good relative to true north
 float32 track_t
 string track_t_ref
 
-# track made good relative to magnetic north
+# Track made good relative to magnetic north
 float32 track_m
 string track_m_ref
 
-# measured horizontal speed in knots
+# Measured horizontal speed in knots
 float32 speed_n
 string speed_n_unit
 
-# measured horizontal speed in km/hr
+# Measured horizontal speed in km/hr
 float32 speed_k
 string speed_k_unit
 
-# mode indicator
+# Mode indicator
 string mode_indicator

--- a/msg/Gpvtg.msg
+++ b/msg/Gpvtg.msg
@@ -3,7 +3,7 @@ Header header
 
 string message_id
 
-#track made good relative to true north
+# track made good relative to true north
 float64 track_t
 string track_t_ref
 

--- a/msg/Gpvtg.msg
+++ b/msg/Gpvtg.msg
@@ -4,7 +4,7 @@ Header header
 string message_id
 
 # track made good relative to true north
-float64 track_t
+float32 track_t
 string track_t_ref
 
 # track made good relative to magnatic north

--- a/msg/Gpvtg.msg
+++ b/msg/Gpvtg.msg
@@ -7,7 +7,7 @@ string message_id
 float32 track_t
 string track_t_ref
 
-# track made good relative to magnatic north
+# track made good relative to magnetic north
 float32 track_m
 string track_m_ref
 

--- a/msg/Gpvtg.msg
+++ b/msg/Gpvtg.msg
@@ -19,4 +19,5 @@ string speed_a_unit
 float32 speed_b
 string speed_b_unit
 
+# mode indicator
 string mode

--- a/msg/Gpvtg.msg
+++ b/msg/Gpvtg.msg
@@ -1,0 +1,22 @@
+# Message from GPVTG NMEA String
+Header header
+
+string message_id
+
+#track made good relative to true north
+float64 tmg_a
+string tmg_a_ref
+
+# track made good relative to magnatic north
+float64 tmg_b
+string tmg_b_ref
+
+# measured horizontal speed in knots
+float32 speed_a
+string speed_a_unit
+
+# measured horizontal speed in km/hr
+float32 speed_b
+string speed_b_unit
+
+string mode

--- a/msg/Gpzda.msg
+++ b/msg/Gpzda.msg
@@ -1,0 +1,16 @@
+# Message from GPRMC NMEA String
+Header header
+
+string message_id
+
+float64 utc_seconds
+
+uint8 day
+uint8 month
+uint16 year
+
+# local time zone offset from GMT (0 to +/-13 hr)
+int8 local_zone_hour
+
+#local time zone offset from GMT (0 to 59 minutes)
+uint8 local_zone_minutes

--- a/msg/Gpzda.msg
+++ b/msg/Gpzda.msg
@@ -3,7 +3,7 @@ Header header
 
 string message_id
 
-float64 utc_seconds
+uint32 utc_seconds
 
 uint8 day
 uint8 month

--- a/msg/Gpzda.msg
+++ b/msg/Gpzda.msg
@@ -10,7 +10,7 @@ uint8 month
 uint16 year
 
 # local time zone offset from GMT (0 to +/-13 hr)
-int8 local_zone_hour
+int8 hour_offset_gmt
 
 #local time zone offset from GMT (0 to 59 minutes)
-uint8 local_zone_minutes
+uint8 minute_offset_gmt

--- a/msg/Gpzda.msg
+++ b/msg/Gpzda.msg
@@ -9,8 +9,8 @@ uint8 day
 uint8 month
 uint16 year
 
-# local time zone offset from GMT (0 to +/-13 hr)
+# Local time zone offset from GMT (0 to +/-13 hr)
 int8 hour_offset_gmt
 
-#local time zone offset from GMT (0 to 59 minutes)
+# Local time zone offset from GMT (0 to 59 minutes)
 uint8 minute_offset_gmt


### PR DESCRIPTION
## Bug fix
`diff_age` in GGA type sentences can sometimes be float numbers. See references [[1]](https://receiverhelp.trimble.com/alloy-gnss/en-us/NMEA-0183messages_GGA.html) and [[2]](http://lefebure.com/articles/nmea-gga/).

## New sentences
GPVTG is useful for interpreting speed and heading. References [[1]](https://receiverhelp.trimble.com/alloy-gnss/en-us/NMEA-0183messages_VTG.html) and [[2]](https://www.sparkfun.com/datasheets/GPS/NMEA%20Reference%20Manual1.pdf).
GPZDA is useful for syncing date and time. References [[1]](https://receiverhelp.trimble.com/alloy-gnss/en-us/NMEA-0183messages_ZDA.html) and [[2]](https://www.sparkfun.com/datasheets/GPS/NMEA%20Reference%20Manual1.pdf).

Commits have been fully tested in production codes.
