### PR TITLE
Add unit for latitude and longitude

### DIFF
--- a/msg/Gpgga.msg
+++ b/msg/Gpgga.msg
@@ -6,7 +6,9 @@ string message_id
 # UTC seconds from midnight
 float64 utc_seconds
 
+# Latitude in decimal degrees
 float64 lat
+# Longitude in decimal degrees
 float64 lon
 
 string lat_dir

--- a/msg/Gprmc.msg
+++ b/msg/Gprmc.msg
@@ -6,7 +6,9 @@ string message_id
 float64 utc_seconds
 string position_status
 
+# Latitude in decimal degrees
 float64 lat
+# Longitude in decimal degrees
 float64 lon
 
 string lat_dir


### PR DESCRIPTION
The unit for latitude and longitude were not explicit :

In nmea frames, degree-minute (dddmm.mm) are used, but in [nmea_navsat_driver](https://github.com/ros-drivers/nmea_navsat_driver), [decimal degrees are used](https://github.com/ros-drivers/nmea_navsat_driver/blob/b168f499349e5f26e3aed9982deb44ed2f41f8e2/src/libnmea_navsat_driver/parser.py#L78-L101)

We ended up using decimal degrees and I propose to make it explicit in the messages.