### PR TITLE
Create Gphdt.msg

### DIFF
--- a/msg/Gphdt.msg
+++ b/msg/Gphdt.msg
@@ -1,0 +1,10 @@
+# Message from GPHDT NMEA String
+std_msgs/Header header
+
+string message_id
+
+# Heading in degrees
+float64 heading
+
+# Relative to T(rue north)
+string rel_to


### PR DESCRIPTION
HDT messages are used to communicate heading using a moving baseline system. They are a part of the NMEA 0183 standard and should be included in this library.